### PR TITLE
Default values for fields in Scheme Parser

### DIFF
--- a/lib/membrane_h264_plugin/parser/nalu_parser.ex
+++ b/lib/membrane_h264_plugin/parser/nalu_parser.ex
@@ -46,7 +46,7 @@ defmodule Membrane.H264.Parser.NALuParser do
     {parsed_fields, scheme_parser_state} =
       SchemeParser.parse_with_scheme(
         nalu_header,
-        Schemes.NALuHeader.scheme(),
+        Schemes.NALuHeader,
         new_scheme_parser_state
       )
 
@@ -89,16 +89,16 @@ defmodule Membrane.H264.Parser.NALuParser do
   defp parse_proper_nalu_type(payload, state, type) do
     case type do
       :sps ->
-        SchemeParser.parse_with_scheme(payload, Schemes.SPS.scheme(), state)
+        SchemeParser.parse_with_scheme(payload, Schemes.SPS, state)
 
       :pps ->
-        SchemeParser.parse_with_scheme(payload, Schemes.PPS.scheme(), state)
+        SchemeParser.parse_with_scheme(payload, Schemes.PPS, state)
 
       :idr ->
-        SchemeParser.parse_with_scheme(payload, Schemes.Slice.scheme(), state)
+        SchemeParser.parse_with_scheme(payload, Schemes.Slice, state)
 
       :non_idr ->
-        SchemeParser.parse_with_scheme(payload, Schemes.Slice.scheme(), state)
+        SchemeParser.parse_with_scheme(payload, Schemes.Slice, state)
 
       _unknown_nalu_type ->
         {%{}, state}

--- a/lib/membrane_h264_plugin/parser/nalu_parser/scheme.ex
+++ b/lib/membrane_h264_plugin/parser/nalu_parser/scheme.ex
@@ -5,7 +5,7 @@ defmodule Membrane.H264.Parser.NALuParser.Scheme do
 
   # A NALu scheme is defining the internal structure of the NALu
   # and describes the fields which need to by fetched from the binary.
-  # The `Membrane.H264.Parser.SchemeParserScheme` behaviour defines a single
+  # The `Membrane.H264.Parser.SchemeParserScheme` behaviour defines a
   # callback: `scheme/0`, which returns the description of NALu structure.
   # The syntax which can be used to describe the NALu scheme is designed to
   # match the syntax forms used in *7.1.* chapter of the *"ITU-T Rec. H.264 (01/2012)"*.
@@ -23,7 +23,9 @@ defmodule Membrane.H264.Parser.NALuParser.Scheme do
   # * save_as_global_state_t: saves the current parser state, concerning the NALu which is
   #   currently processed, in the map under the `:__global__` key in the state. Information
   #   from the saved state can be used while parsing the following NALus.
-
+  #
+  # Furthermore, `Scheme` behavior defines `defaults/0` callback,
+  # which is used to provide the default values of the fields.
   alias Membrane.H264.Parser.NALuParser.SchemeParser
 
   @type field_t :: {any(), SchemeParser.field_t()}
@@ -59,4 +61,5 @@ defmodule Membrane.H264.Parser.NALuParser.Scheme do
   @type t :: list(directive_t())
 
   @callback scheme() :: t()
+  @callback defaults() :: keyword()
 end

--- a/lib/membrane_h264_plugin/parser/nalu_parser/scheme_parser.ex
+++ b/lib/membrane_h264_plugin/parser/nalu_parser/scheme_parser.ex
@@ -77,14 +77,18 @@ defmodule Membrane.H264.Parser.NALuParser.SchemeParser do
   Returns the remaining bitstring and the stated updated
   with the information fetched from the NALu.
   """
-  @spec parse_with_scheme(binary(), Scheme.t(), t(), list(integer())) ::
+  @spec parse_with_scheme(binary(), module(), t(), list(integer())) ::
           {map(), t()}
   def parse_with_scheme(
         payload,
-        scheme,
+        scheme_module,
         state \\ new(),
         iterators \\ []
       ) do
+    scheme = scheme_module.scheme()
+    defaults_map = Map.new(scheme_module.defaults())
+    state = Map.update!(state, :__local__, &Map.merge(defaults_map, &1))
+
     {_remaining_payload, state} = do_parse_with_scheme(payload, scheme, state, iterators)
     {get_local_state(state), state}
   end

--- a/lib/membrane_h264_plugin/parser/nalu_parser/schemes/nalu_header.ex
+++ b/lib/membrane_h264_plugin/parser/nalu_parser/schemes/nalu_header.ex
@@ -3,6 +3,9 @@ defmodule Membrane.H264.Parser.NALuParser.Schemes.NALuHeader do
   @behaviour Membrane.H264.Parser.NALuParser.Scheme
 
   @impl true
+  def defaults(), do: []
+
+  @impl true
   def scheme(),
     do: [
       field: {:forbidden_zero_bit, :u1},

--- a/lib/membrane_h264_plugin/parser/nalu_parser/schemes/pps.ex
+++ b/lib/membrane_h264_plugin/parser/nalu_parser/schemes/pps.ex
@@ -3,6 +3,9 @@ defmodule Membrane.H264.Parser.NALuParser.Schemes.PPS do
   @behaviour Membrane.H264.Parser.NALuParser.Scheme
 
   @impl true
+  def defaults(), do: []
+
+  @impl true
   def scheme(),
     do: [
       field: {:pic_parameter_set_id, :ue},

--- a/lib/membrane_h264_plugin/parser/nalu_parser/schemes/slice.ex
+++ b/lib/membrane_h264_plugin/parser/nalu_parser/schemes/slice.ex
@@ -3,6 +3,9 @@ defmodule Membrane.H264.Parser.NALuParser.Schemes.Slice do
   @behaviour Membrane.H264.Parser.NALuParser.Scheme
 
   @impl true
+  def defaults(), do: []
+
+  @impl true
   def scheme(),
     do: [
       field: {:first_mb_in_slice, :ue},

--- a/lib/membrane_h264_plugin/parser/nalu_parser/schemes/sps.ex
+++ b/lib/membrane_h264_plugin/parser/nalu_parser/schemes/sps.ex
@@ -6,6 +6,9 @@ defmodule Membrane.H264.Parser.NALuParser.Schemes.SPS do
   alias Membrane.H264.Parser.NALuParser.Scheme
 
   @impl true
+  def defaults(), do: [chroma_format_idc: 1, separate_colour_plane_flag: 0]
+
+  @impl true
   def scheme(),
     do: [
       field: {:profile_idc, :u8},


### PR DESCRIPTION
This PR: 
* Adds defaults/0 callback in Scheme.
* Makes parse_with_scheme/4 accept scheme module rather than the scheme itself as the second argument.
* Adds handling of default values during parsing