### PR TITLE
Add support for remote stream's decoder configuration parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package can be installed by adding `membrane_h264_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_h264_plugin, "~> 0.2.0"}
+    {:membrane_h264_plugin, "~> 0.3.0"}
   ]
 end
 ```

--- a/lib/membrane_h264_plugin/parser/decoder_configuration_record.ex
+++ b/lib/membrane_h264_plugin/parser/decoder_configuration_record.ex
@@ -1,6 +1,8 @@
 defmodule Membrane.H264.Parser.DecoderConfigurationRecord do
   @moduledoc """
-  Utility functions for parsing AVC Configuration Record
+  Utility functions for parsing AVC Configuration Record.
+
+  The structure of the record is described in section 5.2.4.1.1 of MPEG-4 part 15 (ISO/IEC 14496-15).
   """
   @enforce_keys [
     :sps,
@@ -8,23 +10,27 @@ defmodule Membrane.H264.Parser.DecoderConfigurationRecord do
     :avc_profile_indication,
     :avc_level,
     :profile_compatibility,
-    :length_size
+    :length_size_minus_one
   ]
   defstruct @enforce_keys
 
+  @typedoc "Structure representing the Decoder Configuartion Record"
   @type t() :: %__MODULE__{
           sps: [binary()],
           pps: [binary()],
           avc_profile_indication: non_neg_integer(),
           profile_compatibility: non_neg_integer(),
           avc_level: non_neg_integer(),
-          length_size: non_neg_integer()
+          length_size_minus_one: non_neg_integer()
         }
 
+  @doc """
+  Parses the DCR.
+  """
   @spec parse(binary()) :: {:ok, t()} | {:error, any()}
   def parse(
         <<1::8, avc_profile_indication::8, profile_compatibility::8, avc_level::8, 0b111111::6,
-          length_size::2, 0b111::3, rest::bitstring>>
+          length_size_minus_one::2, 0b111::3, rest::bitstring>>
       ) do
     {sps, rest} = parse_sps(rest)
     {pps, _rest} = parse_pps(rest)
@@ -35,7 +41,7 @@ defmodule Membrane.H264.Parser.DecoderConfigurationRecord do
       avc_profile_indication: avc_profile_indication,
       profile_compatibility: profile_compatibility,
       avc_level: avc_level,
-      length_size: length_size
+      length_size_minus_one: length_size_minus_one
     }
     |> then(&{:ok, &1})
   end

--- a/lib/membrane_h264_plugin/parser/decoder_configuration_record.ex
+++ b/lib/membrane_h264_plugin/parser/decoder_configuration_record.ex
@@ -1,0 +1,56 @@
+defmodule Membrane.H264.Parser.DecoderConfigurationRecord do
+  @moduledoc """
+  Utility functions for parsing AVC Configuration Record
+  """
+  @enforce_keys [
+    :sps,
+    :pps,
+    :avc_profile_indication,
+    :avc_level,
+    :profile_compatibility,
+    :length_size
+  ]
+  defstruct @enforce_keys
+
+  @type t() :: %__MODULE__{
+          sps: [binary()],
+          pps: [binary()],
+          avc_profile_indication: non_neg_integer(),
+          profile_compatibility: non_neg_integer(),
+          avc_level: non_neg_integer(),
+          length_size: non_neg_integer()
+        }
+
+  @spec parse(binary()) :: {:ok, t()} | {:error, any()}
+  def parse(
+        <<1::8, avc_profile_indication::8, profile_compatibility::8, avc_level::8, 0b111111::6,
+          length_size::2, 0b111::3, rest::bitstring>>
+      ) do
+    {sps, rest} = parse_sps(rest)
+    {pps, _rest} = parse_pps(rest)
+
+    %__MODULE__{
+      sps: sps,
+      pps: pps,
+      avc_profile_indication: avc_profile_indication,
+      profile_compatibility: profile_compatibility,
+      avc_level: avc_level,
+      length_size: length_size
+    }
+    |> then(&{:ok, &1})
+  end
+
+  def parse(_data), do: {:error, :unknown_pattern}
+
+  defp parse_sps(<<num_of_sps::5, rest::bitstring>>) do
+    do_parse_array(num_of_sps, rest)
+  end
+
+  defp parse_pps(<<num_of_pps::8, rest::bitstring>>), do: do_parse_array(num_of_pps, rest)
+
+  defp do_parse_array(amount, rest, acc \\ [])
+  defp do_parse_array(0, rest, acc), do: {Enum.reverse(acc), rest}
+
+  defp do_parse_array(remaining, <<size::16, data::binary-size(size), rest::bitstring>>, acc),
+    do: do_parse_array(remaining - 1, rest, [data | acc])
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H264.TODO.Mixfile do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
   @github_url "https://github.com/membraneframework-labs/membrane_h264_plugin"
 
   def project do


### PR DESCRIPTION
This PR adds the support of parsing of the decoder configuration record that arrives in stream format, just like in `membrane_h264_ffmpeg_plugin` package.

On DCR arrival the parser will try to parse it to extract PPS and SPS values that will be prepended to the following buffer received by the parser.