### PR TITLE
Fix stream format conversion fixtures path

### DIFF
--- a/test/parser/stream_structure_conversion_test.exs
+++ b/test/parser/stream_structure_conversion_test.exs
@@ -15,10 +15,10 @@ defmodule Membrane.H264.StreamStructureConversionTest do
                    |> Path.wildcard()
                    |> Enum.reject(&String.contains?(&1, ["no-sps", "no-pps", "sps-pps-non-idr"]))
 
-  @avc1_au_fixtures "../fixtures/msf/*-avc1-au.ms" |> Path.expand(__DIR__) |> Path.wildcard()
-  @avc1_nalu_fixtures "../fixtures/msf/*-avc1-nalu.ms" |> Path.expand(__DIR__) |> Path.wildcard()
-  @avc3_au_fixtures "../fixtures/msf/*-avc3-au.ms" |> Path.expand(__DIR__) |> Path.wildcard()
-  @avc3_nalu_fixtures "../fixtures/msf/*-avc3-nalu.ms" |> Path.expand(__DIR__) |> Path.wildcard()
+  @avc1_au_fixtures "../fixtures/ms/*-avc1-au.ms" |> Path.expand(__DIR__) |> Path.wildcard()
+  @avc1_nalu_fixtures "../fixtures/ms/*-avc1-nalu.ms" |> Path.expand(__DIR__) |> Path.wildcard()
+  @avc3_au_fixtures "../fixtures/ms/*-avc3-au.ms" |> Path.expand(__DIR__) |> Path.wildcard()
+  @avc3_nalu_fixtures "../fixtures/ms/*-avc3-nalu.ms" |> Path.expand(__DIR__) |> Path.wildcard()
 
   defp make_annexb_pipeline(alignment, parsers) do
     parser_chain = make_parser_chain(parsers)


### PR DESCRIPTION
The name of the folder where the fixture found is `ms` and not `msf`