### PR TITLE
Prevent accessing `nil` NALu splitter/parser on end of stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package can be installed by adding `membrane_h264_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_h264_plugin, "~> 0.9.0"}
+    {:membrane_h264_plugin, "~> 0.9.1"}
   ]
 end
 ```

--- a/lib/membrane_h264_plugin/parser.ex
+++ b/lib/membrane_h264_plugin/parser.ex
@@ -305,7 +305,8 @@ defmodule Membrane.H264.Parser do
   end
 
   @impl true
-  def handle_end_of_stream(:input, ctx, state) when state.mode != :au_aligned do
+  def handle_end_of_stream(:input, ctx, state)
+      when state.mode != :au_aligned and ctx.pads.input.start_of_stream? do
     {last_nalu_payload, nalu_splitter} = NALuSplitter.split(<<>>, true, state.nalu_splitter)
     {last_nalu, nalu_parser} = NALuParser.parse_nalus(last_nalu_payload, state.nalu_parser)
     {maybe_improper_aus, au_splitter} = AUSplitter.split(last_nalu, true, state.au_splitter)

--- a/mix.exs
+++ b/mix.exs
@@ -1,8 +1,8 @@
 defmodule Membrane.H264.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.9.0"
-  @github_url "https://github.com/membraneframework-labs/membrane_h264_plugin"
+  @version "0.9.1"
+  @github_url "https://github.com/membraneframework/membrane_h264_plugin"
 
   def project do
     [


### PR DESCRIPTION
With the recent update to Membrane Core 1.0 it's possible to receive `:end_of_stream` without receiving `:start_of_stream` before. This results in accessing `NALu` splitter and parsers that are `nil`, causing a runtime error.