### PR TITLE
Release v0.10.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Membrane H26x Plugin
 
-[![Hex.pm](https://img.shields.io/hexpm/v/membrane_h264_plugin.svg)](https://hex.pm/packages/membrane_h264_plugin)
-[![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](https://hexdocs.pm/membrane_h264_plugin)
-[![CircleCI](https://circleci.com/gh/membraneframework/membrane_h264_plugin.svg?style=svg)](https://circleci.com/gh/membraneframework/membrane_h264_plugin)
+[![Hex.pm](https://img.shields.io/hexpm/v/membrane_h264_plugin.svg)](https://hex.pm/packages/membrane_h26x_plugin)
+[![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](https://hexdocs.pm/membrane_h26x_plugin)
+[![CircleCI](https://circleci.com/gh/membraneframework/membrane_h264_plugin.svg?style=svg)](https://circleci.com/gh/membraneframework/membrane_h26x_plugin)
 
 Membrane H.264 and H.265 parsers.
 It is a pair of Membrane elements responsible for parsing the incoming H.264 and H.265 streams. The parsing is done as a sequence of the following steps:
@@ -22,7 +22,7 @@ The package can be installed by adding `membrane_h26x_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_h26x_plugin, "~> 0.10.4"}
+    {:membrane_h26x_plugin, "~> 0.10.5"}
   ]
 end
 ```
@@ -58,8 +58,8 @@ end
 
 ## Copyright and License
 
-Copyright 2022, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane_h264_plugin)
+Copyright 2022, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane_h26x_plugin)
 
-[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane_h264_plugin)
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane_h26x_plugin)
 
 Licensed under the [Apache License, Version 2.0](LICENSE)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H26x.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.10.4"
+  @version "0.10.5"
   @github_url "https://github.com/membraneframework/membrane_h26x_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* bumps version to v0.10.5
* fixes link in the readme so that they point to `membrane_h26x_plugin` instead of `membrane_h264_plugin`