### PR TITLE
Discard filler_data before first VCL NALu. Bump to v0.10.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package can be installed by adding `membrane_h26x_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_h26x_plugin, "~> 0.10.6"}
+    {:membrane_h26x_plugin, "~> 0.10.7"}
   ]
 end
 ```

--- a/lib/membrane_h264_plugin/h264/au_splitter.ex
+++ b/lib/membrane_h264_plugin/h264/au_splitter.ex
@@ -54,7 +54,7 @@ defmodule Membrane.H264.AUSplitter do
     }
   end
 
-  @non_vcl_nalu_types_at_au_beginning [:sps, :pps, :aud, :sei, :filler_data]
+  @non_vcl_nalu_types_at_au_beginning [:sps, :pps, :aud, :sei]
   @non_vcl_nalu_types_at_au_end [:end_of_seq, :end_of_stream]
 
   @doc """
@@ -107,6 +107,9 @@ defmodule Membrane.H264.AUSplitter do
           rest_nalus,
           %__MODULE__{state | nalus_acc: state.nalus_acc ++ [first_nalu]}
         )
+
+      first_nalu.type == :filler_data ->
+        do_split(rest_nalus, state)
 
       true ->
         Membrane.Logger.warning(

--- a/lib/membrane_h264_plugin/h264/au_splitter.ex
+++ b/lib/membrane_h264_plugin/h264/au_splitter.ex
@@ -109,8 +109,9 @@ defmodule Membrane.H264.AUSplitter do
         )
 
       first_nalu.type == :filler_data ->
+        # let's silently discard filler_data as it contains no information
         Membrane.Logger.warning(
-          "AUSplitter: Improper transition: filler data NALu before first VCL NALu"
+          "AUSplitter: Improper transition: filler data NALu before the first VCL NALu in AU"
         )
 
         do_split(rest_nalus, state)

--- a/lib/membrane_h264_plugin/h264/au_splitter.ex
+++ b/lib/membrane_h264_plugin/h264/au_splitter.ex
@@ -109,7 +109,7 @@ defmodule Membrane.H264.AUSplitter do
         )
 
       first_nalu.type == :filler_data ->
-        # let's silently discard filler_data as it contains no information
+        # let' discard filler_data as it contains no information
         Membrane.Logger.warning(
           "AUSplitter: Improper transition: filler data NALu before the first VCL NALu in AU"
         )

--- a/lib/membrane_h264_plugin/h264/au_splitter.ex
+++ b/lib/membrane_h264_plugin/h264/au_splitter.ex
@@ -54,7 +54,7 @@ defmodule Membrane.H264.AUSplitter do
     }
   end
 
-  @non_vcl_nalu_types_at_au_beginning [:sps, :pps, :aud, :sei]
+  @non_vcl_nalu_types_at_au_beginning [:sps, :pps, :aud, :sei, :filler_data]
   @non_vcl_nalu_types_at_au_end [:end_of_seq, :end_of_stream]
 
   @doc """

--- a/lib/membrane_h264_plugin/h264/au_splitter.ex
+++ b/lib/membrane_h264_plugin/h264/au_splitter.ex
@@ -109,7 +109,7 @@ defmodule Membrane.H264.AUSplitter do
         )
 
       first_nalu.type == :filler_data ->
-        # let' discard filler_data as it contains no information
+        # We can safely discard filler_data as it contains no information
         Membrane.Logger.warning(
           "AUSplitter: Improper transition: filler data NALu before the first VCL NALu in AU"
         )

--- a/lib/membrane_h264_plugin/h264/au_splitter.ex
+++ b/lib/membrane_h264_plugin/h264/au_splitter.ex
@@ -109,6 +109,10 @@ defmodule Membrane.H264.AUSplitter do
         )
 
       first_nalu.type == :filler_data ->
+        Membrane.Logger.warning(
+          "AUSplitter: Improper transition: filler data NALu before first VCL NALu"
+        )
+
         do_split(rest_nalus, state)
 
       true ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H26x.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.10.6"
+  @version "0.10.7"
   @github_url "https://github.com/membraneframework/membrane_h26x_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* discards `filler_data` NALu if it's encountered before the first VCL NALu of given AU (it's not spec-compliant to have filler data before the first VCL NALU but we can recover from it as filler data does not contain any information)
* Bumps version to v0.10.7