### PR TITLE
Resync immediately after an improper transition in the H264 AU splitter.  Bump to v0.10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package can be installed by adding `membrane_h26x_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_h26x_plugin, "~> 0.10.8"}
+    {:membrane_h26x_plugin, "~> 0.10.9"}
   ]
 end
 ```

--- a/lib/membrane_h264_plugin/h264/au_splitter.ex
+++ b/lib/membrane_h264_plugin/h264/au_splitter.ex
@@ -108,20 +108,12 @@ defmodule Membrane.H264.AUSplitter do
           %__MODULE__{state | nalus_acc: state.nalus_acc ++ [first_nalu]}
         )
 
-      first_nalu.type == :filler_data ->
-        # We can safely discard filler_data as it contains no information
-        Membrane.Logger.warning(
-          "AUSplitter: Improper transition: filler data NALu before the first VCL NALu in AU"
-        )
-
-        do_split(rest_nalus, state)
-
       true ->
         Membrane.Logger.warning(
           "AUSplitter: Improper transition, first_nalu: #{inspect(first_nalu)}"
         )
 
-        state
+        do_split(rest_nalus, state)
     end
   end
 
@@ -169,7 +161,7 @@ defmodule Membrane.H264.AUSplitter do
           "AUSplitter: Improper transition, first_nalu: #{inspect(first_nalu)}"
         )
 
-        state
+        do_split(rest_nalus, state)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H26x.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.10.8"
+  @version "0.10.9"
   @github_url "https://github.com/membraneframework/membrane_h26x_plugin"
 
   def project do


### PR DESCRIPTION
This PR is a backport of https://github.com/membraneframework/membrane_h26x_plugin/pull/86